### PR TITLE
Fix the order of actual and expected response

### DIFF
--- a/lib/rspec/graphql_integration/matchers/deep_eq.rb
+++ b/lib/rspec/graphql_integration/matchers/deep_eq.rb
@@ -2,12 +2,10 @@ module RSpec
   module GraphqlIntegration
     module Matchers
       ##
-      # This matcher recursively compares nested Ruby Hashes and Arrays while ignoring
+      # This helper method recursively compares nested Ruby Hashes and Arrays while ignoring
       # the order of elements in Arrays.
       module DeepEq
-        extend RSpec::Matchers::DSL
-
-        matcher(:deep_eq) { |expected| match { |actual| deep_eq?(actual, expected) } }
+        module_function
 
         def deep_eq?(actual, expected)
           return arrays_deep_eq?(actual, expected) if expected.is_a?(Array) && actual.is_a?(Array)
@@ -20,8 +18,8 @@ module RSpec
         def arrays_deep_eq?(actual, expected)
           expected = expected.clone
 
-          actual.each do |array|
-            index = expected.find_index { |element| deep_eq?(array, element) }
+          actual.each do |actual_array|
+            index = expected.find_index { |expected_array| deep_eq?(actual_array, expected_array) }
             return false if index.nil?
 
             expected.delete_at(index)

--- a/spec/example_schema/types/query.rb
+++ b/spec/example_schema/types/query.rb
@@ -2,12 +2,22 @@ require "graphql"
 
 require_relative "./objects/user"
 
+##
+# This class is for simulating a database
+class User
+  def self.first
+    nil
+  end
+end
+
 module Types
   class Query < GraphQL::Schema::Object
     field(:current_user, Types::Objects::User, null: false) do
       argument(:user_name, String, required: false)
     end
     def current_user(**args)
+      return User.first unless User.first.nil?
+
       {
         id: 1,
         name: "John Doe",

--- a/spec/graphql/queries/missing_request_file.json
+++ b/spec/graphql/queries/missing_request_file.json
@@ -1,0 +1,6 @@
+{
+  "currentUser": {
+    "id": "1",
+    "name": "John Doe"
+  }
+}

--- a/spec/graphql/queries/missing_response_file.graphql
+++ b/spec/graphql/queries/missing_response_file.graphql
@@ -1,6 +1,0 @@
-query {
-  currentUser {
-    id
-    name
-  }
-}

--- a/spec/graphql/queries/response_variables_spec.rb
+++ b/spec/graphql/queries/response_variables_spec.rb
@@ -1,6 +1,14 @@
 RSpec.describe "Query.currentUser" do
   context "when response_variables are defined" do
-    let(:response_variables) { { user_name: "John Doe" } }
+    let(:response_variables) do
+      # We need to put the mocking of User.first here so the actual_response does not
+      # trigger it but only the expected_response. This way, we simulate the creation
+      # of a database object during the loading of the response file.
+      allow(User).to receive(:first).and_return(user)
+
+      { user_name: "Maria Doe" }
+    end
+    let(:user) { { id: 1, name: "Maria Doe" } }
 
     it { is_expected.to match_graphql_response }
   end


### PR DESCRIPTION
This is necessary when database objects are created during the loading of the expected response.