### PR TITLE
Drop support for Ruby 3.0 and 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
           - ruby: 3.4
           - ruby: 3.3
           - ruby: 3.2
-          - ruby: 3.1
-          - ruby: 3.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Drop support for Ruby 3.0 and 3.1
 - Drop support for Ruby 2.7
 
 ## [0.2.0] - 2023-01-04


### PR DESCRIPTION
They are both EOL